### PR TITLE
chore: return lnurlp status and error message when no data can be retrieved

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ type Config struct {
 }
 
 type ErrorResponse struct {
-	Status int
-	Message string
+	Status int `json:"status"`
+	Message string `json:"message"`
 }
 
 type LNResponse struct {


### PR DESCRIPTION
Fixes https://github.com/getAlby/lightning-address-details-proxy/issues/7

Currently returns a response like:
```
{
    "lnurlp": null,
    "keysend": null,
    "nostr": null,
    "error": {
        "status": 404,
        "message": "No details: https://getalby.com/.well-known/lnurlp/somenonexistentusername - <nil>"
    }
}
```

I am wondering if it would be better to return a response with errors for each:
```
errors: {
  lnurlp: {status: ..., message: ...},
  keysend: {status: ..., message: ...},
  nostr: {status: ..., message: ...}
}
```

What do you guys think?